### PR TITLE
Use atomic access with memory barriers

### DIFF
--- a/jack/pcm_jack.c
+++ b/jack/pcm_jack.c
@@ -124,7 +124,7 @@ static int pcm_poll_block_check(snd_pcm_ioplug_t *io)
 
 	if (io->state == SND_PCM_STATE_RUNNING ||
 	    (io->state == SND_PCM_STATE_PREPARED && io->stream == SND_PCM_STREAM_CAPTURE)) {
-		avail = snd_pcm_avail_update(io->pcm);
+		avail = snd_pcm_jack_avail(io);
 		if (avail >= 0 && avail < jack->min_avail) {
 			while (read(io->poll_fd, &buf, sizeof(buf)) == sizeof(buf))
 				;
@@ -141,7 +141,7 @@ static int pcm_poll_unblock_check(snd_pcm_ioplug_t *io)
 	snd_pcm_sframes_t avail;
 	snd_pcm_jack_t *jack = io->private_data;
 
-	avail = snd_pcm_avail_update(io->pcm);
+	avail = snd_pcm_jack_avail(io);
 	/* In draining state poll_fd is used to wait
 	 * till all pending frames are played.
 	 * Therefore it has to be guarantee that a poll event is also generated

--- a/jack/pcm_jack.c
+++ b/jack/pcm_jack.c
@@ -41,7 +41,7 @@ typedef struct {
 	char **port_names;
 	unsigned int num_ports;
 	snd_pcm_uframes_t boundary;
-	unsigned int hw_ptr;
+	snd_pcm_uframes_t hw_ptr;
 	unsigned int sample_bits;
 	snd_pcm_uframes_t min_avail;
 


### PR DESCRIPTION
for variables which will be accessed by the ALSA and JACK thread

Has to be rebased when https://github.com/twischer-adit/alsa-plugins/pull/1 was upstreamed